### PR TITLE
Fix file-based strategies: clean loader, CJS runtime, and runnable sc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "dev": "NEXT_SKIP_TURBOPACK=1 next dev",
     "build": "next build",
     "start": "next start",
-    "strategies:run": "TS_NODE_TRANSPILE_ONLY=1 ts-node --compiler-options '{\"module\":\"CommonJS\"}' server/engine/runFileStrategies.ts",
-    "report:files:daily": "TS_NODE_TRANSPILE_ONLY=1 ts-node --compiler-options '{\"module\":\"CommonJS\"}' server/reports/reportDailyFromFiles.ts"
+  "strategies:run": "TS_NODE_TRANSPILE_ONLY=1 ts-node -P tsconfig.cjs.json server/engine/runFileStrategies.ts",
+  "report:daily": "TS_NODE_TRANSPILE_ONLY=1 ts-node -P tsconfig.cjs.json server/reports/reportDaily.ts",
+  "report:files:daily": "TS_NODE_TRANSPILE_ONLY=1 ts-node --compiler-options '{\"module\":\"CommonJS\"}' server/reports/reportDailyFromFiles.ts"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.7",
@@ -31,14 +32,14 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4.1.13",
-    "@types/node": "^20",
+    "@types/node": "^20.12.12",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
     "tailwindcss": "^4.1.13",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5",
-    "ts-node": "^10"
+    "typescript": "^5.5.4",
+    "ts-node": "^10.9.2"
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "ts-node": {
+    "transpileOnly": true
+  }
+}


### PR DESCRIPTION
…ripts

- Replace corrupted strategies/loader.ts
- Add tsconfig.cjs.json for CommonJS runtime
- Add npm scripts: strategies:run and report:daily
- Pin devDependencies for ts-node, typescript, @types/node
- Ensure scripts run under ts-node without ESM/bundler errors